### PR TITLE
Update package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -97,7 +97,7 @@ function cleanup() {
 }
 
 function buildDocx(markdownPath, baseFileName) {
-    var docxFilePath = createDocxFile(markdownPath, course ? (course + '_') : '' + baseFileName + '.docx');
+    var docxFilePath = createDocxFile(markdownPath, course ? (course + '_' + baseFileName + '.docx')) : '' + baseFileName + '.docx');
     return docxFilePath;
 }
 


### PR DESCRIPTION
When package.js is run with --course parameter, it doesn't create .docx files.

Missing proper docx file name when --course parameter is provided. Added + _baseFileName + '.docx'_ under true statement.